### PR TITLE
정확도 수정

### DIFF
--- a/mode_one.py
+++ b/mode_one.py
@@ -351,7 +351,7 @@ def main(scr, level, id, language):
     ship_explode_sound = load_sound('ship_explode.ogg')
     load_music('music_loop.ogg')
 
-    aliennum = 20 # 아이템 나오는 alien 숫자(aliennum 이상 남은 경우)
+    aliennum = 3 # 아이템 나오는 alien 숫자(aliennum 이상 남은 경우)
     setaliennum = 10 # 4웨이브마다 초기 웨이브 수
     speedup = 0.5 # 4웨이브마다 speed += speedup
     aliennumup = 2 # 4웨이브 주기로 alienthiswave = int(alienthiswave * aliennumup)

--- a/mode_one.py
+++ b/mode_one.py
@@ -1055,6 +1055,7 @@ def main(scr, level, id, language):
                     alien.table()
                     Explosion.position(alien.rect.center)
                     aliensLeftThisWave, kill_count, score = kill_alien(alien, aliensLeftThisWave, kill_count, score)
+                    missilesFired += 1
                     if soundFX:
                         alien_explode_sound.play()
             for missile in Missile.active:

--- a/mode_two.py
+++ b/mode_two.py
@@ -691,6 +691,7 @@ def main(scr, level, id, language):
                     alien.table()
                     Explosion.position(alien.rect.center)
                     aliensLeftThisWave, kill_count, score = kill_alien(alien, aliensLeftThisWave, kill_count, score)
+                    missilesFired += 1
                     if soundFX:
                         alien_explode_sound.play()
             for bomb in bombs2:
@@ -912,7 +913,7 @@ def main(scr, level, id, language):
             distItem -= 1
             if half_tf :
                 distRect.topleft = screen.get_rect().inflate(0, 0).midtop
-                
+
             else :
                 distRect.topright = screen.get_rect().inflate(0, 0).midtop
             screen.blit(dist, distRect)

--- a/shooting_game.py
+++ b/shooting_game.py
@@ -1014,6 +1014,7 @@ def main(scr, level, id, language):
                     alien.table()
                     Explosion.position(alien.rect.center)
                     aliensLeftThisWave, kill_count, score = kill_alien(alien, aliensLeftThisWave, kill_count, score)
+                    missilesFired += 1
                     if soundFX:
                         alien_explode_sound.play()
             for missile in Missile.active:


### PR DESCRIPTION
- 폭탄 사용시에도 missilesfired 카운트되도록 수정했습니다. 폭탄은 모두 명중하는 것으로 처리하여 폭탄만 사용했을 시 정확도는 100%가 됩니다.
- 아이템 드랍되는 빈도(aliennum)는 시연용으로 자주 나오도록 낮춰놓은게 게임 난이도 상 적당한것같아서 그대로뒀고, 협동 모드에서도 더 자주나오도록 수정했습니다.